### PR TITLE
Edit writing up until "The empty interface{}"

### DIFF
--- a/README.md
+++ b/README.md
@@ -940,7 +940,7 @@ Again, this is a very standard implementation of a getter function for our store
 
 > NOTE: Consider the case where our application uses multiple threads. In this scenario, passing pointers to the same memory location can also potentially result in a race condition. In other words, we aren't only potentially corrupting our data&mdash;we could also cause a panic from a data race.
 
-Please keep in mind that there is intrinsically nothing wrong with returning pointers. However, the expanded scope of variables (and the number of owners that point to those variables) is the most important consideration when working with pointers. This is what categorises our previous example as a smelly operation. This is also why common Go constructors are absolutely fine:
+Please keep in mind that there is intrinsically nothing wrong with returning pointers. However, the expanded scope of variables (and the number of owners pointing to those variables) is the most important consideration when working with pointers. This is what categorises our previous example as a smelly operation. This is also why common Go constructors are absolutely fine:
 
 ```go
 func AddName(user *User, name string) {

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ q, err := ch.QueueDeclare(QueueOptions{
 })
 ```
 
-This solves two problems: misusing comments, and accidentally labeling the variables incorrectly. Of course, we can still confuse properties with the wrong value, but in these cases, it will be much easier to determine where our mistake lies within the code. The ordering of the properties also doesn't matter anymore, so incorrectly ordering the input values is no longer a concern. The last added bonus of this technique is that we can use our Option `struct` to infer the default values of our function's input parameters. When structures in Go are declared, all properties are initialised to their default value. This means that our `QueueDeclare` option can actually be invoked in the following way:
+This solves two problems: misusing comments, and accidentally labeling the variables incorrectly. Of course, we can still confuse properties with the wrong value, but in these cases, it will be much easier to determine where our mistake lies within the code. The ordering of the properties also doesn't matter anymore, so incorrectly ordering the input values is no longer a concern. The last added bonus of this technique is that we can use our `QueueOptions` struct to infer the default values of our function's input parameters. When structures in Go are declared, all properties are initialised to their default value. This means that our `QueueDeclare` option can actually be invoked in the following way:
 
 ```go
 q, err := ch.QueueDeclare(QueueOptions{

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ First, indentation hell makes it difficult for other developers to understand th
 
 Indentation hell can result in reader fatigue if a developer has to constantly parse unwieldy code like the sample above. Naturally, this is something we want to avoid at all costs.
 
-So, how do we clean this function? Fortunately, it's actually quite simple. On our first iteration, we will try to ensure that we are returning an error as soon as possible. Instead of nested the `if` and `else` statements, we want to "push our code to the left," so to speak. Take a look:
+So, how do we clean this function? Fortunately, it's actually quite simple. On our first iteration, we will try to ensure that we are returning an error as soon as possible. Instead of nesting the `if` and `else` statements, we want to "push our code to the left," so to speak. Take a look:
 
 ```go
 func GetItem(extension string) (Item, error) {


### PR DESCRIPTION
My previous PR stopped right before Clean Go. This PR contains edits up to but not including the section titled "The empty interface{}."

I wasn't too sure about the following bits and was hoping you could weigh in to clarify what was meant:

> ... but it could just as well have been the opposite case: (see *Closures Are Function Pointers*)

> When constructing our Pipe struct with NullWriter (rather than a different writer), when invoking our Save function, nothing will happen. (see last paragraph before "The empty interface{}").

Feel free to suggest edits and/or request changes as needed :)