### PR TITLE
Improve error handling 

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,7 +794,7 @@ And our HTTP handler function can then be refactored to check for a specific err
 func GetItemHandler(w http.ReponseWriter, r http.Request) {
     item, err := clean.GetItem("123")
     if err != nil {
-        if err.Type() == clean.ErrItemNotFound {
+        if errors.Is(err.Type(), clean.ErrItemNotFound) {
             http.Error(w, err.Error(), http.StatusNotFound)
 	        return
         }

--- a/README.md
+++ b/README.md
@@ -698,7 +698,7 @@ By simply representing the error as a variable (`ErrItemNotFound`), we've ensure
 func GetItemHandler(w http.ReponseWriter, r http.Request) {
     item, err := clean.GetItem("123")
     if err != nil {
-        if err == clean.ErrItemNotFound {
+        if errors.Is(err, clean.ErrItemNotFound) {
            http.Error(w, err.Error(), http.StatusNotFound)
 	        return
         }


### PR DESCRIPTION
Using `errors.Is()` is better than `==` for comparing errors