### PR TITLE
add the valid return signature for the getStringResult() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ Basically, we create a new structure named `RMQChannel` that contains the `amqp.
 We'll use this idea of wrapping functions to introduce more clean and safe code later when discussing `interface{}`.
 
 ### Variable Scope
-Now, let's take a step back and revisit the idea of writing smaller functions. This has another nice side effect that we didn't cover in the previous chapter: Writing smaller functions can typically eliminate reliance on mutable variables that leak into the global scope. 
+Now, let's take a step back and revisit the idea of writing smaller functions. This has another nice side effect that we didn't cover in the previous chapter: Writing smaller functions can typically eliminate reliance on mutable variables that leak into the global scope.
 
 Global variables are problematic and don't belong in clean code; they make it very difficult for programmers to understand the current state of a variable. If a variable is global and mutable, then by definition, its value can be changed by any part of the codebase. At no point can you guarantee that this variable is going to be a specific value... And that's a headache for everyone. This is yet another example of a trivial problem that's exacerbated when the codebase expands.
 
@@ -452,7 +452,7 @@ func main() {
     case 64:
         // do nothing
     }
-    
+
     fmt.Println(val)
 }
 ```
@@ -475,7 +475,7 @@ func getStringResult(num int) (string, error) {
     case 64:
         // do nothing
     }
-    return "" 
+    return "", nil
 }
 
 func main() {


### PR DESCRIPTION
I copied and pasted and noticed that the return signature didn't match. Also thanks for providing a great alternative design. 